### PR TITLE
fix!:  Move constant exports to its own path

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,11 @@
       "import": "./dist/index.js",
       "default": "./dist/index.js"
     },
+    "./const": {
+      "types": "./dist/const.d.ts",
+      "import": "./dist/const.js",
+      "default": "./dist/const.js"
+    },
     "./imo": {
       "import": "./dist/imo.min.js"
     },

--- a/post-build.ps1
+++ b/post-build.ps1
@@ -1,8 +1,8 @@
 Write-Host "Starting post-build script..." -ForegroundColor Green
 
 # Copy the types file to the dist folder
-$srcFiles = @("./src/types.ts", "./src/global.d.ts")
-$destFiles = @("index.d.ts", "global.d.ts")
+$srcFiles = @("./src/types.ts", "./src/global.d.ts", "./src/const-types.ts")
+$destFiles = @("index.d.ts", "global.d.ts", "const.d.ts")
 $destFolder = "dist"
 if (!(Test-Path -Path $destFolder)) {
     New-Item -ItemType Directory -Path $destFolder | Out-Null

--- a/src/const-types.ts
+++ b/src/const-types.ts
@@ -1,0 +1,9 @@
+/**
+ * Identifier used to tag IMO options.
+ */
+export declare const imPostingOptionsId: string;
+
+/**
+ * Identifier used to tag IMO UI options.
+ */
+export declare const imoUiOptionsId: string;

--- a/src/const.ts
+++ b/src/const.ts
@@ -1,0 +1,1 @@
+export { imPostingOptionsId, imoUiOptionsId } from "./shared/options.js";

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,6 @@ import type { ImoUiFactoryOptions } from "./types.js";
 import { getInitialImoUiOptions } from "./shared/options.js";
 import { initImoUiOptions } from "./lib/state/imoUiOptions";
 import type { CorePiece } from "@collagejs/core";
-export { imPostingOptionsId, imoUiOptionsId } from "./shared/options.js";
 
 const cssMount = cssMountFactory('piece');
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -92,16 +92,6 @@ export type ImoUiFactoryOptions = {
 export declare function imoUiFactory(options?: ImoUiFactoryOptions): Promise<CorePiece<{}>>;
 
 /**
- * Identifier used to tag IMO options.
- */
-export declare const imPostingOptionsId: string;
-
-/**
- * Identifier used to tag IMO UI options.
- */
-export declare const imoUiOptionsId: string;
-
-/**
  * Supported `p-retry` options.
  */
 export type RetryOptions = Omit<PRetryOptions, 'onFailedAttempt' | 'shouldRetry' | 'shouldConsumeRetry' | 'signal'>;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,7 +10,7 @@ export default defineConfig({
     cjsCssPlugin({
         serverPort: 4444,
         projectId: 'cjs-imo',
-        entryPoints: ['src/index.ts', 'src/imo-ui.ts'],
+        entryPoints: ['src/index.ts', 'src/const.js', 'src/imo-ui.ts'],
         assetFileNames: 'assets/[name][extname]',
     }),
     viteTest(),


### PR DESCRIPTION
This fixes an issue where importing constants in Node code unintentionally triggers Svelte code.